### PR TITLE
Reverting brace-style rule to default

### DIFF
--- a/tools-javascript-formatter/.eslintrc
+++ b/tools-javascript-formatter/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "airbnb",
   "parser": "babel-eslint",
   "rules": {
-    "brace-style": [2, "stroustrup"],
     "indent": ["error", "tab"],
     "react/prefer-es6-class": 0,
     "react/jsx-indent": ["error", "tab"]


### PR DESCRIPTION
Airbnb uses [eslint default brace-syles rule](http://eslint.org/docs/rules/brace-style) which looks much better.