### PR TITLE
correct ident check rules on jsx props

### DIFF
--- a/tools-javascript-formatter/.eslintrc
+++ b/tools-javascript-formatter/.eslintrc
@@ -4,7 +4,8 @@
   "rules": {
     "indent": ["error", "tab"],
     "react/prefer-es6-class": 0,
-    "react/jsx-indent": ["error", "tab"]
+    "react/jsx-indent": ["error", "tab"],
+    "react/jsx-indent-props": ["error", "tab"]
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
jsx props indentation was required to use 2 space, corrected to use tabs instead