### PR TITLE
fix(javascript-formatter/eslint): add missing rules configuration

### DIFF
--- a/tools-javascript-formatter/.eslintrc
+++ b/tools-javascript-formatter/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "airbnb",
   "parser": "babel-eslint",
   "rules": {
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": ['*.test.js', '.spec.js']}],
     "indent": ["error", "tab"],
     "react/prefer-es6-class": 0,
     "react/jsx-indent": ["error", "tab"],


### PR DESCRIPTION
the rule import/no-extraneous-dependencies do not know where is the test file.
This change remove the complains about using devDependency in a test file