### PR TITLE
fix: disable no-tabs rules

### DIFF
--- a/tools-javascript-formatter/.eslintrc
+++ b/tools-javascript-formatter/.eslintrc
@@ -3,6 +3,7 @@
   "parser": "babel-eslint",
   "rules": {
     "import/no-extraneous-dependencies": ["error", {"devDependencies": ['*.test.js', '.spec.js']}],
+    "no-tabs": "off",
     "indent": ["error", "tab"],
     "react/prefer-es6-class": 0,
     "react/jsx-indent": ["error", "tab"],


### PR DESCRIPTION
no-tabs rules where added to airbnb eslint rules wich we depend on,
this change disable said rules

https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/CHANGELOG.md#600--2016-09-06