### PR TITLE
fix(github-root): Ignore default build directory

### DIFF
--- a/tools-root-github/.gitignore
+++ b/tools-root-github/.gitignore
@@ -37,3 +37,6 @@ target/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 .classpath
+
+# Talend web apps build directory
+build/


### PR DESCRIPTION
Ignore Talend web apps build directory by default