### PR TITLE
style(eslint): skip Shape propType check

### DIFF
--- a/tools-javascript/.eslintrc
+++ b/tools-javascript/.eslintrc
@@ -9,6 +9,7 @@
     "react/jsx-indent": ["error", "tab"],
     "react/jsx-indent-props": ["error", "tab"],
     "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
+    "react/no-unused-prop-types": [2, { "skipShapeProps": true }],
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The linter throw an error on `Shape` propType usage check, even when it is unable to check that.
ex: 
```javascript
function MyComponent(props) {
	return props.actions.map((action) => <div>{action.label}</div>)
}
MyComponent.propTypes = {
	actions: React.PropTypes.arrayOf(
		React.PropTypes.shape({
			label: React.PropTypes.string,
		})
	),
}
```
An error will be thrown on actions.**.label because the linter cannot check properly that label is used.

**What is the new behavior?**
*This is a proposal*
There won't be any check on `shape` propType.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
