### PR TITLE
fix: Internet Explorer does not support Object.assign method

### DIFF
--- a/tools-javascript/compilation/react/.babelrc
+++ b/tools-javascript/compilation/react/.babelrc
@@ -1,7 +1,14 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": [
+    "es2015",
+    "react"
+  ],
   "ignore": [
     "**/**/*.css"
   ],
-  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
+  "plugins": [
+    "transform-class-properties",
+    "transform-object-assign",
+    "transform-object-rest-spread"
+  ]
 }


### PR DESCRIPTION
Introduces by https://github.com/Talend/react-talend-components/pull/57
