### PR TITLE
Add comments for non-mandatory information

### DIFF
--- a/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md
+++ b/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,11 +11,10 @@ e.g. https://jira.talendforge.org/browse/TPSVC-XXX
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
 
-# You can add more checkboxes here
+<> You can add more checkboxes here
  
 **[ ] This PR introduces a breaking change**
  
-# **Original Template**
-
-# https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md 
+<> **Original Template**
+<> https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md 
 

--- a/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md
+++ b/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,10 +11,10 @@ e.g. https://jira.talendforge.org/browse/TPSVC-XXX
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
 
-<> You can add more checkboxes here
+<!-- You can add more checkboxes here -->
  
 **[ ] This PR introduces a breaking change**
  
-<> **Original Template**
-<> https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md 
+<!-- **Original Template** -->
+<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
 

--- a/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md
+++ b/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,12 @@ e.g. https://jira.talendforge.org/browse/TPSVC-XXX
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
+
+# You can add more checkboxes here
  
 **[ ] This PR introduces a breaking change**
  
-**Original Template**
-https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md 
+# **Original Template**
+
+# https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md 
+


### PR DESCRIPTION
At the moment the PR template shows the original link to the PR template. However, it's not needed, and it should be made invisible. 

In addition, add a small statement about the fact that additional checkboxes can be added.

