### PR TITLE
chores(eslint): no more forbidden proptypes

### DIFF
--- a/tools-javascript/.eslintrc
+++ b/tools-javascript/.eslintrc
@@ -10,6 +10,7 @@
     "react/jsx-indent-props": ["error", "tab"],
     "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
     "react/no-unused-prop-types": [2, { "skipShapeProps": true }],
+    "react/forbid-prop-types": [0],
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
As discussed with @jmfrancois, this rule is not used and cause many useless errors.