### PR TITLE
doc(java): changed maven formatter plugin to fixed version

### DIFF
--- a/tools-java-formatter/README.md
+++ b/tools-java-formatter/README.md
@@ -23,7 +23,7 @@ To setup the automatic formatter validation for every maven build please add the
 		<plugin>
 			<groupId>net.revelc.code.formatter</groupId>
 			<artifactId>formatter-maven-plugin</artifactId>
-			<version>1.6.0-SNAPSHOT</version>
+			<version>2.0.1</version>
 			<executions>
 	          <execution>
 	            <goals>


### PR DESCRIPTION
changed the documentation for the java formatter in order to use a release version of the formatter maven plugin instead of a SNAPSHOT one.