### PR TITLE
fix(contributing): forbid @ in branch name

### DIFF
--- a/tools-root-github/CONTRIBUTING.md
+++ b/tools-root-github/CONTRIBUTING.md
@@ -128,6 +128,8 @@ so that the branch can easily be traced back to you.
 
 The first part of the branch name after ```username/``` should be the jira-id, followed by a hyphen and a short description. Use underscores to separate words in the short description.
 
+The `@` character is forbidden, since this is not compatible with our CI tools.
+
 ## <a name="squash"></a> Squash
 
 Within a pull request, a relatively small number of commits that break the problem into logical steps 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

On projects with Jenkins CI on it, there are tools used by devops that are not compatible with `@` in branch name.

**What is the chosen solution to this problem?**
 
Add a note to forbid this char.
