### PR TITLE
doc(java): update the import order setup

### DIFF
--- a/tools-java-formatter/README.md
+++ b/tools-java-formatter/README.md
@@ -1,7 +1,7 @@
 ### IntelliJ idea
 * Install [Eclipse Code Formatter](https://plugins.jetbrains.com/plugin/6546) plugin
 * Import the java formatter file [src/main/resources/talend_java_eclipse_formatter.xml](src/main/resources/talend_java_eclipse_formatter.xml)
-* setup the "import order" by choosing "From file" and select the file [src/main/resources/talend.importorder](src/main/resources/talend.importorder)
+* Setup the "import order" by choosing "From file" and select the file [src/main/resources/talend.importorder](src/main/resources/talend.importorder)
 * Disable import on the fly (Settings... -> Editor -> General -> Auto Import, uncheck Optimize imports on the fly)
 * Disable `.*` imports (Settings... -> Editor -> Code Style -> Java -> Imports)
   - `Class count to use import with '*'` : 999
@@ -11,9 +11,9 @@ That's it, you're good to go !
 
 ### Eclipse
 * Open Eclipse preferences
-* Select the Java->Code Style->Formatter section.
-* click on the *Import* button and select the file  [src/main/resources/talend_java_eclipse_formatter.xml](src/main/resources/talend_java_eclipse_formatter.xml)
-* Select the Java->Code Style->Organize Imports.
+* Select the Java -> Code Style -> Formatter section.
+* Click on the *Import* button and select the file  [src/main/resources/talend_java_eclipse_formatter.xml](src/main/resources/talend_java_eclipse_formatter.xml)
+* Select the Java -> Code Style -> Organize Imports.
 * click on the *Import...* button and select the file  [src/main/resources/talend.importorder](src/main/resources/talend.importorder)
 
 ### Maven

--- a/tools-java-formatter/README.md
+++ b/tools-java-formatter/README.md
@@ -1,7 +1,7 @@
 ### IntelliJ idea
 * Install [Eclipse Code Formatter](https://plugins.jetbrains.com/plugin/6546) plugin
 * Import the java formatter file [src/main/resources/talend_java_eclipse_formatter.xml](src/main/resources/talend_java_eclipse_formatter.xml)
-* Set the order import manually as followed `java;javax;org;com;`
+* setup the "import order" by choosing "From file" and select the file [src/main/resources/talend.importorder](src/main/resources/talend.importorder)
 * Disable import on the fly (Settings... -> Editor -> General -> Auto Import, uncheck Optimize imports on the fly)
 * Disable `.*` imports (Settings... -> Editor -> Code Style -> Java -> Imports)
   - `Class count to use import with '*'` : 999
@@ -12,7 +12,9 @@ That's it, you're good to go !
 ### Eclipse
 * Open Eclipse preferences
 * Select the Java->Code Style->Formatter section.
-* click on the *Import* button and select the file  (src/main/resources/talend_java_eclipse_formatter.xml)
+* click on the *Import* button and select the file  [src/main/resources/talend_java_eclipse_formatter.xml](src/main/resources/talend_java_eclipse_formatter.xml)
+* Select the Java->Code Style->Organize Imports.
+* click on the *Import...* button and select the file  [src/main/resources/talend.importorder](src/main/resources/talend.importorder)
 
 ### Maven
 #### setup formatter validation


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

Intellij and eclipse had 2 different ways of defining the java import order and also have different definitions.

**What is the chosen solution to this problem?**
have one single source for the import order definition, the IntelliJ Eclipse formatter plugin is also compatible with the eclipse file *.importorder* . Also specify the eclipse procedure to set this up.