### PR TITLE
chore(eslint): add rule for comma-dangle

### DIFF
--- a/tools-javascript/.eslintrc
+++ b/tools-javascript/.eslintrc
@@ -11,6 +11,13 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
     "react/no-unused-prop-types": [2, { "skipShapeProps": true }],
     "react/forbid-prop-types": [0],
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+      "functions": "never"
+    }]
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
Currently, prietter add a comma dangle on the functions but no define on your code style.
Add a eslint rule comma-dangle to fix that