### PR TITLE
Add lineEnding property to code formatter setting

### DIFF
--- a/tools-java-formatter/README.md
+++ b/tools-java-formatter/README.md
@@ -29,23 +29,24 @@ To setup the automatic formatter validation for every maven build please add the
 			<artifactId>formatter-maven-plugin</artifactId>
 			<version>2.0.1</version>
 			<executions>
-	          <execution>
-	            <goals>
-	              <goal>validate</goal>
-	            </goals>
-	          </execution>
-	        </executions>
-            <configuration>
-            	<encoding>UTF-8</encoding>
-                <configFile>talend_java_eclipse_formatter.xml</configFile>
-            </configuration>
+				<execution>
+					<goals>
+						<goal>validate</goal>
+					</goals>
+				</execution>
+			</executions>
+			<configuration>
+				<encoding>UTF-8</encoding>
+				<configFile>talend_java_eclipse_formatter.xml</configFile>
+				<lineEnding>LF</lineEnding>
+			</configuration>
 			<dependencies>
-	          <dependency>
-	            <groupId>org.talend.tools</groupId>
-	            <artifactId>java-formatter</artifactId>
-	            <version>0.1.0</version>
-	          </dependency>
-	        </dependencies>
+				<dependency>
+					<groupId>org.talend.tools</groupId>
+					<artifactId>java-formatter</artifactId>
+					<version>0.1.0</version>
+				</dependency>
+			</dependencies>
 		</plugin>
 	</plugins>
 </build>


### PR DESCRIPTION
This is because the code formatter plugin automatically choose lineEnding characters according to the operation system. On windows, it will be CRLF, which is different from the linux/macos. If we do a -Dformat on windows, it will mark every lines of all the text files as modified.
By forcing the lineEnding property to LF, it will convert all CRLF to LF during the formatting step and save it to the files. This behavior is consistent with the suggested core.autocrlf setting for projects with developpers accross different platforms.