### PR TITLE
chore(eslint): align lint with prettier rules

### DIFF
--- a/tools-javascript/.eslintrc
+++ b/tools-javascript/.eslintrc
@@ -2,9 +2,11 @@
   "extends": "airbnb",
   "parser": "babel-eslint",
   "rules": {
+    "arrow-parens": [2, "as-needed"],
     "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js"]}],
-    "no-tabs": "off",
     "indent": ["error", "tab", { "SwitchCase": 1 }],
+    "no-mixed-operators": "off",
+    "no-tabs": "off",
     "react/prefer-es6-class": 0,
     "react/jsx-indent": ["error", "tab"],
     "react/jsx-indent-props": ["error", "tab"],


### PR DESCRIPTION
ESlint did not match Prettier config regarding arrow-parens
Align ESlint config regarding arrow-parens to fit Prettier one

### Futher read

* https://eslint.org/docs/rules/arrow-parens
* https://eslint.org/docs/rules/no-mixed-operators