### PR TITLE
fix hub-detect defaults + adding exclusions to HubDetectMojo

### DIFF
--- a/talend-tools-maven-plugin/pom.xml
+++ b/talend-tools-maven-plugin/pom.xml
@@ -48,6 +48,11 @@
       <version>${maven.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-artifact-transfer</artifactId>
+      <version>0.9.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.blackducksoftware.integration</groupId>
       <artifactId>hub-common</artifactId>
       <version>23.0.1</version>

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -88,7 +88,7 @@ public class HubDetectMojo extends BlackduckBase {
     /**
      * The log level used for the inspection.
      */
-    @Parameter(property = "hub-detect.logLevel", defaultValue = "TRACE") // ALL doesn't work with mvn slf4j default impl
+    @Parameter(property = "hub-detect.logLevel", defaultValue = "INFO")
     private String logLevel;
 
     /**

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -200,8 +200,7 @@ public class HubDetectMojo extends BlackduckBase {
         config.put("detect.source.path", rootPath);
         config.put("detect.maven.scope", scope);
         if (systemVariables == null || !systemVariables.containsKey("detect.output.path")) {
-            config.put("detect.output.path",
-                    new File(rootProject.getBuild().getDirectory(), "blackduck").getAbsolutePath());
+            config.put("detect.output.path", new File(rootProject.getBuild().getDirectory(), "blackduck").getAbsolutePath());
         }
         if (exclusions != null) {
             config.put("detect.hub.signature.scanner.exclusion.patterns", exclusions.stream().filter(Objects::nonNull).map(e -> {

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -199,6 +199,10 @@ public class HubDetectMojo extends BlackduckBase {
         config.put("detect.project.name", blackduckName);
         config.put("detect.source.path", rootPath);
         config.put("detect.maven.scope", scope);
+        if (systemVariables == null || !systemVariables.containsKey("detect.output.path")) {
+            config.put("detect.output.path",
+                    new File(rootProject.getBuild().getOutputDirectory(), "blackduck").getAbsolutePath());
+        }
         if (exclusions != null) {
             config.put("detect.hub.signature.scanner.exclusion.patterns", exclusions.stream().filter(Objects::nonNull).map(e -> {
                 final File file = new File(rootProject.getBasedir(), e.trim());

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -300,10 +300,11 @@ public class HubDetectMojo extends BlackduckBase {
         if (systemVariables == null || !systemVariables.containsKey("detect.output.path")) {
             config.put("detect.output.path", new File(rootProject.getBuild().getDirectory(), "blackduck").getAbsolutePath());
         }
+        final String enforcedExcluded = "/blackduck/";
         if (exclusions != null) {
             config.put("detect.hub.signature.scanner.exclusion.patterns",
-                    Stream.concat(Stream.of("/blackduck/"), exclusions.stream().filter(Objects::nonNull).map(String::trim))
-                            .map(p -> (p.startsWith("/") ? "" : "/") + p + (p.endsWith("/") ? "" : ('/'))).collect(joining(",")));
+                    Stream.concat(Stream.of(enforcedExcluded), exclusions.stream().filter(Objects::nonNull).map(String::trim))
+                            .collect(joining(",")));
         } else {
             config.put("detect.hub.signature.scanner.exclusion.patterns", "/blackduck/");
         }

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -182,7 +182,7 @@ public class HubDetectMojo extends BlackduckBase {
         command.add(java.getAbsolutePath());
         if (systemVariables != null) {
             command.addAll(systemVariables.entrySet().stream()
-                    .map(e -> String.format("-D%s=%s", e.getKey(), e.getValue().replace("${rootProject}", rootPath)))
+                    .map(e -> String.format("-D%s=%s", e.getKey(), handlePlaceholders(rootPath, e.getValue())))
                     .collect(toList()));
         }
         final ProcessBuilder processBuilder = new ProcessBuilder().inheritIO().command(command);
@@ -240,5 +240,9 @@ public class HubDetectMojo extends BlackduckBase {
         if (exitStatus != expectedExitCode) {
             throw new IllegalStateException(String.format("Invalid exit status: %d", exitStatus));
         }
+    }
+
+    private String handlePlaceholders(final String rootPath, final String value) {
+        return value.replace("$rootProject", rootPath);
     }
 }

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -198,6 +198,7 @@ public class HubDetectMojo extends BlackduckBase {
         config.put("logging.level.com.blackducksoftware.integration", logLevel);
         config.put("detect.project.name", blackduckName);
         config.put("detect.source.path", rootPath);
+        config.put("detect.maven.scope", scope);
         if (exclusions != null) {
             config.put("detect.hub.signature.scanner.exclusion.patterns", exclusions.stream().filter(Objects::nonNull).map(e -> {
                 final File file = new File(rootProject.getBasedir(), e.trim());

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -201,7 +201,7 @@ public class HubDetectMojo extends BlackduckBase {
         config.put("detect.maven.scope", scope);
         if (systemVariables == null || !systemVariables.containsKey("detect.output.path")) {
             config.put("detect.output.path",
-                    new File(rootProject.getBuild().getOutputDirectory(), "blackduck").getAbsolutePath());
+                    new File(rootProject.getBuild().getDirectory(), "blackduck").getAbsolutePath());
         }
         if (exclusions != null) {
             config.put("detect.hub.signature.scanner.exclusion.patterns", exclusions.stream().filter(Objects::nonNull).map(e -> {

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -257,7 +257,7 @@ public class HubDetectMojo extends BlackduckBase {
             }
 
             explodedScanCli = new File(rootProject.getBuild().getOutputDirectory(),
-                    "blackduck_" + getClass().getSimpleName() + "_scancli");
+                    "blackduck/" + getClass().getSimpleName() + "_scancli");
             if (!explodedScanCli.exists()) {
                 unzip(scanCliCache, explodedScanCli, true);
             }
@@ -345,7 +345,7 @@ public class HubDetectMojo extends BlackduckBase {
             final URL url = new URL(scanCliDownloadUrl);
             final HttpURLConnection connection = HttpURLConnection.class.cast(url.openConnection());
             final File zip = new File(rootProject.getBuild().getDirectory(),
-                    "blackduck_" + getClass().getSimpleName() + "/scan.cli.zip");
+                    "blackduck/" + getClass().getSimpleName() + "/scan.cli.zip");
             zip.getParentFile().mkdirs();
             final int bufferSize = 81920;
             try (final OutputStream os = new BufferedOutputStream(new FileOutputStream(zip), bufferSize)) {

--- a/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
+++ b/talend-tools-maven-plugin/src/main/java/org/talend/tools/blackduck/HubDetectMojo.java
@@ -262,7 +262,7 @@ public class HubDetectMojo extends BlackduckBase {
                 }
             }
 
-            explodedScanCli = new File(rootProject.getBuild().getOutputDirectory(),
+            explodedScanCli = new File(rootProject.getBuild().getDirectory(),
                     "blackduck/" + getClass().getSimpleName() + "_scancli");
             if (!explodedScanCli.exists()) {
                 unzip(scanCliCache, explodedScanCli, true);


### PR DESCRIPTION
Overall goal is to exclude test/temporary folders hub-detect abusively scans (things we don't deliver).

Also it contains a few default fixes like log level can't be ALL with maven slf4j or the default scope should be runtime which includes compile but not only.