### PR TITLE
upgrading talend-tools-maven-plugin

### DIFF
--- a/tools-root-maven/pom.xml
+++ b/tools-root-maven/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.talend.tools</groupId>
         <artifactId>talend-tools-maven-plugin</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <executions>
           <execution>
             <id>hub-detect</id>


### PR DESCRIPTION
better defaults and built-in in the config exclusion support

note: before merging we need to ensure it is synch-ed on central (http://repo1.maven.org/maven2/org/talend/tools/talend-tools-maven-plugin/maven-metadata.xml include latest=1.0.2)