### PR TITLE
chore: Prettier deals with hex-notation rule

### DIFF
--- a/tools-scss-formatting/.sass-lint.yml
+++ b/tools-scss-formatting/.sass-lint.yml
@@ -53,9 +53,7 @@ rules:
     -
       style: 'short'
   hex-notation:
-    - 1
-    -
-      style: 'uppercase'
+    - 0
   id-name-format:
     - 2
     -


### PR DESCRIPTION
`sass-lint` waits for hex colors in uppercase while `prettier` will change them into lowercase.

To avoid a lot of errors, since Prettier will reformat only change files, I propose to desactivate those errors from that tool