### PR TITLE
chore: update babelrc to use preset-env

### DIFF
--- a/tools-javascript/compilation/react/.babelrc
+++ b/tools-javascript/compilation/react/.babelrc
@@ -1,6 +1,16 @@
 {
   "presets": [
-    "es2015",
+    [
+      "env",
+      {
+        "targets": {
+          "ie": 11,
+          "browsers": [
+            "last 2 versions"
+          ]
+        }
+      }
+    ],
     "react"
   ],
   "ignore": [


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Current babelrc use babel-preset-es2015 which is kind of deprecated.

**What is the chosen solution to this problem?**
Set configuration for babel-preset-env