### PR TITLE
chore: update browserlist to >0.25% + IE11

### DIFF
--- a/tools-javascript/compilation/react/.babelrc
+++ b/tools-javascript/compilation/react/.babelrc
@@ -4,9 +4,10 @@
       "env",
       {
         "targets": {
-          "ie": 11,
           "browsers": [
-            "last 2 versions"
+            ">0.25%",
+            "not op_mini all",
+            "IE 11"
           ]
         }
       }


### PR DESCRIPTION
What is the problem this PR is trying to solve?
(See https://jamie.build/last-2-versions)
last 2 versions as browserlist brings support to a lot more browsers than expected. More code is transpiled, and the bundle is heavier.
You can see the compatible browsers here

What is the chosen solution to this problem?
Change it to >0.25%, IE 11, not op_mini all
You can see the compatible browsers here

This is done on

Talend/ui's babel and autoprefixer conf
Talend/scripts, so when app migrate their conf on it, they will have the new conf