### PR TITLE
Improve Eclipse Java formatter, stop wrapping lines

### DIFF
--- a/tools-java-formatter/src/main/resources/talend_java_eclipse_formatter.xml
+++ b/tools-java-formatter/src/main/resources/talend_java_eclipse_formatter.xml
@@ -151,7 +151,7 @@
 <setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>


### PR DESCRIPTION
# Improve Eclipse Java formatter, stop wrapping lines

The Eclipse formatter currently wraps lines automatically which makes the code harder to read in common use-cases like the use of builders.

Ex:

```java
Record.builder()
  .withType(RECORD)
  .withEntry(entry1)
  .withEntry(entry2)
  .build()
```

Becomes:

```java
Record.builder().withType(RECORD).withEntry(entry1).withEntry(entry2).build()
```

This is worked around in a lot of places by adding an empty comment at the end of lines that should not be wrapped, ex:

```java
Record.builder() //
  .withType(RECORD) //
  .withEntry(entry1) //
  .withEntry(entry2) //
  .build()
```

This shows that it's time for the rule to evolve.

This change makes the formatter preserve wrapping, one is free to remove them manually where necessary.
